### PR TITLE
ci: fix readme-writer (branch name)

### DIFF
--- a/.github/workflows/readme-writer.yml
+++ b/.github/workflows/readme-writer.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: master
+        ref: develop
     - name: Set up python
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
Fix in CI we are using wrong branch name (master)