### PR TITLE
fix: sanoid email notifications

### DIFF
--- a/confs/ovh3/systemd/sanoid.service.d/override.conf
+++ b/confs/ovh3/systemd/sanoid.service.d/override.conf
@@ -1,2 +1,3 @@
 [Unit]
-OnFailure=email-failures@sanoid-%l.service
+# %l specifier is not available in systemd version 241 used on ovh3, use %i instead
+OnFailure=email-failures@sanoid-%i.service


### PR DESCRIPTION
dmesg on ovh3 has errors for the systemd config for sanoid:

```
[    6.583892] systemd[1]: /opt/openfoodfacts-infrastructure/confs/ovh3/systemd/system/../../../common/systemd/system/sanoid_check.service:6: Failed to resolve unit specifiers in 'email-failures@sanoid_check-%l.service', ignoring: Unknown error -57
[    6.589359] systemd[1]: /lib/systemd/system/rpc-statd.service:13: PIDFile= references path below legacy directory /var/run/, updating /var/run/rpc.statd.pid → /run/rpc.statd.pid; please update the unit file accordingly.
[    6.593451] systemd[1]: /opt/openfoodfacts-infrastructure/confs/ovh3/systemd/sanoid.service.d/override.conf:2: Failed to resolve unit specifiers in 'email-failures@sanoid-%l.service', ignoring: Unknown error -57

```

This is because %l for short hostname was added in May 2020: https://github.com/keszybz/systemd/commit/5cb5ad9b58475a1e75d855c7b8c6b7b4e44d897d

but we are running ystemd version 241 from 2019:


```
ovh3:~# systemd --version
systemd 241 (241)
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid
```

Replacing %l with %i