### PR TITLE
fix: link for /srv/off-pro/html/images on off1

### DIFF
--- a/docs/reports/2023-07-off2-off-reinstall.md
+++ b/docs/reports/2023-07-off2-off-reinstall.md
@@ -1017,7 +1017,8 @@ And on off, we need to be able to reach off-pro `export_files` and images:
 sudo mkdir /srv/off-pro/
 sudo chown off:off /srv/off-pro/
 sudo -u off ln -s /mnt/off-pro/cache/export_files /srv/off-pro/export_files
-sudo -u off ln -s /mnt/off-pro/images /srv/off-pro/images
+sudo -u off mkdir /srv/off-pro/html
+sudo -u off ln -s /mnt/off-pro/images /srv/off-pro/html/images
 # verify
 ls -l /srv/off-pro/export_files{,/} /srv/off-pro/images{,/}
 ```


### PR DESCRIPTION
[326329528] /srv/off/lib/ProductOpener/Import.pm 2722 ProductOpener.Import {code => '3760098459032',file => '/srv/off-pro/html/images/products/org-ateliers-bio-de-provence/376/009/845/9032/1.jpg',imagefield => 'front_fr'} did not find image file
[326329529] /srv/off/lib/ProductOpener/Import.pm 2738 ProductOpener.Import {differing_fields => {},differing_products => 0,existing_products => 1,new_products => 0,products => 1} import done
root@off:/srv/off/logs# ls -lrt /srv/off-pro/
export_files/ images/       
root@off:/srv/off/logs# ls -lrt /srv/off-pro/images/^C
root@off:/srv/off/logs# cd /srv/off-pro/
root@off:/srv/off-pro# ls -lrt
total 1
lrwxrwxrwx 1 off off 31 Aug 11 13:34 export_files -> /mnt/off-pro/cache/export_files
lrwxrwxrwx 1 off off 19 Oct 11 15:48 images -> /mnt/off-pro/images

We need the link to be /srv/off-pro/html/images instead of /srv/off-pro/images