### PR TITLE
fix: Update src URL for 502.jpg to root folder

### DIFF
--- a/html/502.html
+++ b/html/502.html
@@ -32,7 +32,7 @@
         🍊🚧 Service Downtime Alert for Open Food Facts 🚧🍊
     </div>
 
-    <img src="./502.jpg">
+    <img src="/502.jpg">
 
     <!-- English Section -->
     <div class="main-content" lang="en">


### PR DESCRIPTION
### What
- Using a relative path for the 502.jpg image will result in a 404 error for the image when attempting to access it from a directory other than the root domain path.

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-infrastructure/assets/150337574/f082faf8-3e5b-450b-8361-4c06a876ac77)

### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) -->

### Part of 
- <!-- #1, please use the most granular issue possible -->
