### PR TITLE
feat: enable proxy caching in off2 nginx proxy

### DIFF
--- a/confs/off2-reverse-proxy/systemd/system/nginx.service.d/override.conf
+++ b/confs/off2-reverse-proxy/systemd/system/nginx.service.d/override.conf
@@ -1,2 +1,3 @@
 [Unit]
 OnFailure=email-failures@nginx.service
+Restart=always

--- a/confs/proxy-off/nginx/log_format.conf
+++ b/confs/proxy-off/nginx/log_format.conf
@@ -1,3 +1,3 @@
 log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                   '$status $body_bytes_sent "$http_referer" '
-                  '"$http_user_agent" "$http_x_forwarded_for"';
+                  '"$http_user_agent" "$http_x_forwarded_for" $upstream_cache_status [$upstream_response_time]';

--- a/confs/proxy-off/nginx/nginx.conf
+++ b/confs/proxy-off/nginx/nginx.conf
@@ -1,0 +1,85 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	# Cache
+	proxy_cache_path /dev/shm/nginx-cache levels=1:2 keys_zone=mycache:10m max_size=100m inactive=2m use_temp_path=off;
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+#
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+#
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+#
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/confs/proxy-off/nginx/openfoodfacts.org
+++ b/confs/proxy-off/nginx/openfoodfacts.org
@@ -43,9 +43,60 @@ server {
     access_log  /var/log/nginx/openfoodfacts.org.log  main buffer=256K flush=1s;
     error_log   /var/log/nginx/openfoodfacts.org.errors.log;
 
+    # Cache small static assets that are frequently requested
+
+
+    location ~ ^/(css/|js/|fonts/|images/(attributes|favicon|icons|illustrations|logos|misc)/|.wellknown/assetlinks.json) {
+    	proxy_cache mycache;
+    	proxy_cache_key $request_uri;
+        proxy_cache_valid any 1m;
+        add_header X-Cache-Status $upstream_cache_status;  
+        proxy_pass http://10.1.0.113:80;
+	# proxy_buffering off disables caching
+        #proxy_buffering off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Host $host;
+        client_max_body_size 512M;
+
+ 	proxy_intercept_errors on;
+        error_page 502 /502.html;
+    }
+
+    # Cache GET /api/ requests for 5s
+    # This is useful in particular for broken apps who request 100s of times the same product
+    
+    location /api/ {
+    	proxy_cache mycache;
+    	proxy_cache_key $host$request_uri$cookie_user;
+        proxy_cache_valid any 5s;
+        add_header X-Cache-Status $upstream_cache_status;  
+        proxy_pass http://10.1.0.113:80;
+	# proxy_buffering off disables caching
+        #proxy_buffering off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Host $host;
+        client_max_body_size 512M;
+
+ 	proxy_intercept_errors on;
+        error_page 502 /502.html;
+    }
+
     location / {
+#    	proxy_cache mycache;
+#    	proxy_cache_key $host$request_uri$cookie_user;
+#        proxy_cache_valid any 5s;
+	# Adds an X-Cache-Status HTTP header in responses to clients: helps debugging the
+        # cache.
+        # https://www.nginx.com/blog/nginx-caching-guide/#Frequently-Asked-Questions-(FAQ)
+        # Eg. X-Cache-Status: HIT
+        add_header X-Cache-Status $upstream_cache_status;  
         proxy_pass http://10.1.0.113:80/;
-        proxy_buffering off;
+	# proxy_buffering off disables caching
+        #proxy_buffering off;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;

--- a/confs/proxy-off/nginx/openfoodfacts.org
+++ b/confs/proxy-off/nginx/openfoodfacts.org
@@ -46,7 +46,7 @@ server {
     # Cache small static assets that are frequently requested
 
 
-    location ~ ^/(css/|js/|fonts/|images/(attributes|favicon|icons|illustrations|logos|misc)/|.wellknown/assetlinks.json) {
+    location ~ ^/(css/|js/|fonts/|images/(attributes|favicon|icons|illustrations|lang|logos|misc|panels|svg)/|.well-known/|api/v./(preferences|attribute_groups)|data/i18n) {
     	proxy_cache mycache;
     	proxy_cache_key $request_uri;
         proxy_cache_valid any 1m;

--- a/confs/proxy-off/nginx/query.openfoodfacts.org
+++ b/confs/proxy-off/nginx/query.openfoodfacts.org
@@ -1,0 +1,34 @@
+server {
+    listen 443;
+    listen [::]:443;
+    server_name  query.openfoodfacts.org;
+
+    access_log  /var/log/nginx/query.off.org.log  main;
+    error_log   /var/log/nginx/query.off.org.errors.log;
+
+    location / {
+        proxy_pass http://10.1.0.115:5511$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_read_timeout 90;
+        client_max_body_size 512M;
+    }
+    ssl_certificate /etc/letsencrypt/live/query.openfoodfacts.org-0001/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/query.openfoodfacts.org-0001/privkey.pem; # managed by Certbot
+
+}
+
+server {
+    if ($host = query.openfoodfacts.org) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+  listen 80;
+  listen [::]:80;
+  server_name  query.openfoodfacts.org;
+
+}
+               


### PR DESCRIPTION
This PR enables proxy caching in off2 nginx proxy for some requests like /api/ and small static assets like CSS, JS and some images like icons.