### PR TITLE
docs: fix some warnings

### DIFF
--- a/docs/linux-server.md
+++ b/docs/linux-server.md
@@ -27,7 +27,7 @@ We use either postfix or exim as a satellite of a smart_host.
 Every outgoing mail must pass through the proxmox mail gateway,
 which is registered in spf record and adds DKIM signature.
 
-For configuration, see [mail - Servers](./mail.md#Servers)
+For configuration, see [mail - Servers](./mail.md#servers)
 
 ## Iptables
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,7 +20,7 @@ We have servers hosted by two providers:
 ### web traffic proxies
 
 - Most services are hosted on ovh,
-  and pass through an nginx proxy (see [promox - HTTP Reverse Proxy](./promox.md#http-reverse-proxy)) 
+  and pass through an nginx proxy (see [proxmox - HTTP Reverse Proxy](./proxmox.md#http-reverse-proxy)) 
   hosted on 101 VM on ovh1 which has a bridge with it's own ip.
 
 - product opener instances (openfoodfacts.org and its cousins) have their own proxy on [off1](#off1)
@@ -70,12 +70,12 @@ Main services:
 
 Located at ovh Strasbourg (sbg3)
 
-Uses [proxmox](./promox.md)
+Uses [proxmox](./proxmox.md)
 
-Part of [proxmox](./promox.md) cluster.
+Part of [proxmox](./proxmox.md) cluster.
 
 Contains lots of small services, as proxmox containers:
-- [http reverse proxy](./promox.md#http-reverse-proxy)
+- [http reverse proxy](./proxmox.md#http-reverse-proxy)
 - [Proxmox mail gateway](./mail.md)
 - blog
 - [odoo (connect)](./odoo.md)
@@ -85,7 +85,7 @@ Contains lots of small services, as proxmox containers:
 
 Located at ovh Roubaix (rbx8)
 
-Part of [proxmox](./promox.md) cluster.
+Part of [proxmox](./proxmox.md) cluster.
 
 Contains two big QEMU VMs hosting lots of docker services.
 One for staging, one for production.

--- a/docs/reports/2023-03-14-off2-opff-reinstall.md
+++ b/docs/reports/2023-03-14-off2-opff-reinstall.md
@@ -64,7 +64,7 @@ I add a problem running `ct_postinstall` as it wasn't able to fetch debian archi
 
 I then simply install `nginx` and `stunnel4` using apt.
 
-I also [configure postfix](../mail#postfix-configuration) and tested it.
+I also [configure postfix](../mail.md#postfix-configuration) and tested it.
 
 ### Adding the IP
 
@@ -288,7 +288,7 @@ sudo rsync --info=progress2 -a -x 10.0.0.1:/srv/opff/html/images/products  /zfs-
 ```
 this took 12 minutes.
 
-Then I sync to ovh3 (see also below [sanoid usage](#sanoid)):
+Then I sync to ovh3 (see also below [sanoid usage](#snapshots-and-syncs-with-sanoid)):
 
 ```bash
 time sudo  syncoid --no-sync-snap zfs-hdd/opff/images root@ovh3.openfoodfacts.org:rpool/opff/images
@@ -504,7 +504,7 @@ I also did it for the data and cache dataset:
 I created a CT followings [How to create a new Container](../proxmox.md#how-to-create-a-new-container) it went all smooth.
 I choosed a 30Gb disk, 0B swap, 4 Cores and 6 Gb memory.
 
-I also [configure postfix](../mail#postfix-configuration) and tested it.
+I also [configure postfix](../mail.md#postfix-configuration) and tested it.
 
 
 ### Installing packages

--- a/docs/reports/2023-06-07-off2-opf-obf-reinstall.md
+++ b/docs/reports/2023-06-07-off2-opf-obf-reinstall.md
@@ -161,7 +161,7 @@ And on ovh3 add them to `sanoid.conf` with `synced_data` template
 I created a CT for obf followings [How to create a new Container](../proxmox.md#how-to-create-a-new-container) it went all smooth.
 I choosed a 30Gb disk, 0B swap, 4 Cores and 6 Gb memory.
 
-I also [configure postfix](../mail#postfix-configuration) and tested it.
+I also [configure postfix](../mail.md#postfix-configuration) and tested it.
 
 **Important:** do not create any user until you changed id maping in lxc conf (see [Mounting volumes](#mounting-volumes)). And also think about creating off user before any other user to avoid having to change users uids, off must have uid 1000.
 
@@ -1596,7 +1596,7 @@ scss:
   templates
 ```
 
-## Annex files difference for obf in git vs server
+## Annex files difference for opf in git vs server
 
 
 **TO DECIDE**

--- a/docs/reports/2023-07-off2-off-reinstall.md
+++ b/docs/reports/2023-07-off2-off-reinstall.md
@@ -45,7 +45,7 @@ I added a disk on zfs-nvme mounted on /var/lib/postgresql/ with 5Gb size and noa
 
 I did not create a user.
 
-I also [configure postfix](../mail#postfix-configuration) and tested it.
+I also [configure postfix](../mail.md#postfix-configuration) and tested it.
 
 ### Installed Postgres
 
@@ -108,7 +108,7 @@ I created a CT for OFF followings [How to create a new Container](../proxmox.md#
 It's 121 (off-memcached)
 I choosed a 15Gb disk on zfs-hdd, 0B swap, 2 Cores and 4 Gb memory.
 
-I also [configure postfix](../mail#postfix-configuration) and tested it.
+I also [configure postfix](../mail.md#postfix-configuration) and tested it.
 
 I did not create a user.
 
@@ -521,7 +521,7 @@ I choosed a 30Gb disk, 0B swap, 8 Cores and 40 Gb memory.
 
 Note that my first container creation failed because unable to mount the ZFS volume ("zfs dataset is busy"…), I had to destroy the dataset and re-create the container.
 
-I also [configure postfix](../mail#postfix-configuration) and tested it.
+I also [configure postfix](../mail.md#postfix-configuration) and tested it.
 
 **Important:** do not create any user until you changed id maping in lxc conf (see [Mounting volumes](#mounting-volumes)). And also think about creating off user before any other user to avoid having to change users uids, off must have uid 1000.
 

--- a/docs/reports/2023-12-08-off1-upgrade.md
+++ b/docs/reports/2023-12-08-off1-upgrade.md
@@ -114,7 +114,7 @@ We decided to disable the SSD card and continue installation.
 
 ### Installing Proxmox
 
-We boot on the USB key that we had brought with promox install CD on it.
+We boot on the USB key that we had brought with proxmox install CD on it.
 
 For Hard disk options, we choose ZFS - RAID1, ashift 12, compress an checksum on, disk size 64G
 
@@ -466,7 +466,7 @@ Simply following [our Munin doc on how to configure a server](../munin.md#how-to
 
 ## Configuring snapshots and syncoid
 
-I first installed sanoid following [install instructions](../sanoid.md#building-sanoid-deb)
+I first installed sanoid following [install instructions](../sanoid.md#how-to-build-and-install-sanoid-deb)
 
 We want to pull snapshots from off1 and to let ovh3 pull our snapshots.
 

--- a/docs/reports/2024-01-04-setting-up-stunnel.md
+++ b/docs/reports/2024-01-04-setting-up-stunnel.md
@@ -118,7 +118,7 @@ I also [configured email](../mail.md#postfix-configuration) in the container.
 
 ## Setting up stunnel on ovh1 stunnel-client
 
-Did the same as above to [set up stunnel on ovh1 proxy](./#setting-up-stunnel-on-off1-proxy).
+Did the same as above to [set up stunnel on ovh1 proxy](#setting-up-stunnel-on-off1-proxy).
 
 I created a key with `ssh-keygen -t ed25519 -C "off@stunnel-client.ovh.openfoodfacts.org"` 
 add it as a deploy key to this projects 

--- a/docs/reports/2024-02-08-prod-redis-install.md
+++ b/docs/reports/2024-02-08-prod-redis-install.md
@@ -11,7 +11,7 @@ I created a CT on off2 followings [How to create a new Container](../proxmox.md#
 
 I did not create a user.
 
-I also [configure postfix](../mail#postfix-configuration) and [tested it](../mail#testing-that-the-gateway-is-well-configured).
+I also [configure postfix](../mail.md#postfix-configuration) and [tested it](../mail#testing-that-the-gateway-is-well-configured).
 
 Cloned this repository in [/opt using a root key as deploy key](../how-to-have-server-config-in-git.md)
 

--- a/docs/reports/2024-03-separate-hdd-docker-vms.md
+++ b/docs/reports/2024-03-separate-hdd-docker-vms.md
@@ -1,7 +1,7 @@
 # 2024-03 separate HDD on docker VMs
 
 We have docker VMs for staging and production.
-Disk are quite big. They use ext4 over a zfs in block mode (as proposed by promox).
+Disk are quite big. They use ext4 over a zfs in block mode (as proposed by proxmox).
 To keep things manageable, in case we have to switch server,
 I propose to split data from system. It might also help with backups.
 


### PR DESCRIPTION
Fixing at least warnings:

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /app/gh_pages
INFO    -  Doc file 'index.md' contains an unrecognized relative link './reports/', it was left as is.
INFO    -  Doc file 'logs-off2.md' contains an unrecognized relative link './reports/2024-01-19-certbot-failure-off2-proxy', it was left as is. Did you mean 'reports/2024-01-19-certbot-failure-off2-proxy.md'?
INFO    -  Doc file 'mail.md' contains an unrecognized relative link './linux-servers#iptables', it was left as is.
WARNING -  Doc file 'overview.md' contains a link './promox.md#http-reverse-proxy', but the target 'promox.md' is not found among documentation files.
WARNING -  Doc file 'overview.md' contains a link './promox.md', but the target 'promox.md' is not found among documentation files.
WARNING -  Doc file 'overview.md' contains a link './promox.md', but the target 'promox.md' is not found among documentation files.
WARNING -  Doc file 'overview.md' contains a link './promox.md#http-reverse-proxy', but the target 'promox.md' is not found among documentation files.
WARNING -  Doc file 'overview.md' contains a link './promox.md', but the target 'promox.md' is not found among documentation files.
INFO    -  Doc file 'reports/2023-03-14-off2-opff-reinstall.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2023-03-14-off2-opff-reinstall.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2023-06-07-off2-opf-obf-reinstall.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2023-07-off2-off-reinstall.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2023-07-off2-off-reinstall.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2023-07-off2-off-reinstall.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2024-01-04-setting-up-stunnel.md' contains an unrecognized relative link './#setting-up-stunnel-on-off1-proxy', it was left as is. Did you mean '#setting-up-stunnel-on-off1-proxy'?
INFO    -  Doc file 'reports/2024-02-08-prod-redis-install.md' contains an unrecognized relative link '../mail#postfix-configuration', it was left as is. Did you mean '../mail.md#postfix-configuration'?
INFO    -  Doc file 'reports/2024-02-08-prod-redis-install.md' contains an unrecognized relative link '../mail#testing-that-the-gateway-is-well-configured', it was left as is. Did you mean '../mail.md#testing-that-the-gateway-is-well-configured'?
INFO    -  Doc file 'linux-server.md' contains a link './mail.md#Servers', but the doc 'mail.md' does not contain an anchor '#Servers'.
INFO    -  Doc file 'reports/2023-03-14-off2-opff-reinstall.md' contains a link '#sanoid', but there is no such anchor on this page.
INFO    -  Doc file 'reports/2023-06-07-off2-opf-obf-reinstall.md' contains a link '#annex-files-difference-for-opf-in-git-vs-server', but there is no such anchor on this page.
INFO    -  Doc file 'reports/2023-12-08-off1-upgrade.md' contains a link '../sanoid.md#building-sanoid-deb', but the doc 'sanoid.md' does not contain an anchor '#building-sanoid-deb'.

```