### PR TITLE
fix: fix typo for zfs-hdd/opf

### DIFF
--- a/confs/off1/sanoid/syncoid-args.conf
+++ b/confs/off1/sanoid/syncoid-args.conf
@@ -8,7 +8,7 @@
 # obf
 --no-sync-snap --no-privilege-elevation --recursive off1operator@10.0.0.2:zfs-hdd/obf zfs-hdd/obf
 # opf
---no-sync-snap --no-privilege-elevation --recursive off1operator@10.0.0.2:zfs-hdd/opf zfs-hdd/obf
+--no-sync-snap --no-privilege-elevation --recursive off1operator@10.0.0.2:zfs-hdd/opf zfs-hdd/opf
 # opff
 --no-sync-snap --no-privilege-elevation --recursive off1operator@10.0.0.2:zfs-hdd/opff zfs-hdd/opff
 # off2 rpool backups


### PR DESCRIPTION
A typo prevented opf data to be synced to off1 in /zfs-hdd/opf

Running once manually:

```
root@off1:/home/stephane# syncoid --no-sync-snap --no-privilege-elevation --recursive off1operator@10.0.0.2:zfs-hdd/opf zfs-hdd/opf
NEWEST SNAPSHOT: autosnap_2024-06-04_15:00:19_hourly
INFO: Sending oldest full snapshot zfs-hdd/opf@autosnap_2024-04-01_00:02:23_monthly (~ 37.7 MB) to new target filesystem:
37.7MiB 0:00:04 [8.15MiB/s] [======================================================>] 100%            
INFO: Updating new target filesystem with incremental zfs-hdd/opf@autosnap_2024-04-01_00:02:23_monthly ... autosnap_2024-06-04_15:00:19_hourly (~ 705.2 GB):
^Z.4GiB 0:17:34 [13.8MiB/s] [====>                                                   ] 10% ETA 2:33:28
```
