### PR TITLE
fix: add missing configuration for stunnel

### DIFF
--- a/confs/ovh-stunnel-client/stunnel/off.conf
+++ b/confs/ovh-stunnel-client/stunnel/off.conf
@@ -21,3 +21,12 @@ ciphers = PSK
 # this file and directory are private
 PSKsecrets = /etc/stunnel/psk/mongodb-psk.txt
 
+# connecting to mongodb on off1
+[OffRedis]
+client = yes
+# expose only in private network
+accept = 10.1.0.113:6379
+connect = proxy2.openfoodfacts.org:6379
+ciphers = PSK
+# this file and directory are private
+PSKsecrets = /etc/stunnel/psk/redis-psk.txt


### PR DESCRIPTION
The versioned configuration file was not the one used in production.