### PR TITLE
chore: pull snapshots from moji to ovh3 server

### DIFF
--- a/confs/ovh3/sanoid/syncoid-args.conf
+++ b/confs/ovh3/sanoid/syncoid-args.conf
@@ -28,3 +28,10 @@
 --no-sync-snap --no-privilege-elevation --recursive ovh3operator@off2.openfoodfacts.org:zfs-nvme/pve rpool/off-backups/off2-nvme-pve
 # off2 rpool (system)
 --no-sync-snap --no-privilege-elevation --recursive ovh3operator@off2.openfoodfacts.org:rpool rpool/off-backups/off2-rpool
+#
+# pulling from moji server
+# We are using a jump host (OSM proxy) to reach moji server
+--no-sync-snap --no-privilege-elevation --recursive --sshoption="ProxyJump=off@45.147.209.254" ovh3operator@osm45.openstreetmap.fr:rpool rpool/moji-backups/moji-rpool
+--no-sync-snap --no-privilege-elevation --recursive --sshoption="ProxyJump=off@45.147.209.254" ovh3operator@osm45.openstreetmap.fr:nvme-zfs/pve rpool/moji-backups/moji-pve-nvme
+--no-sync-snap --no-privilege-elevation --recursive --sshoption="ProxyJump=off@45.147.209.254" ovh3operator@osm45.openstreetmap.fr:hdd-zfs/pve rpool/moji-backups/moji-pve-hdd
+--no-sync-snap --no-privilege-elevation --recursive --sshoption="ProxyJump=off@45.147.209.254" ovh3operator@osm45.openstreetmap.fr:hdd-zfs/backups rpool/moji-backups/backups


### PR DESCRIPTION
I've tested it on ovh3 (ex: `syncoid --no-sync-snap --no-privilege-elevation --recursive --sshoption="ProxyJump=off@45.147.209.254" ovh3operator@osm45.openstreetmap.fr:rpool rpool/moji-backups/moji-rpool`), the sync works well.