### PR TITLE
fix: mongoDB double backup removed

### DIFF
--- a/confs/off2/sanoid/syncoid-args.conf
+++ b/confs/off2/sanoid/syncoid-args.conf
@@ -1,7 +1,5 @@
 ## pulling from off1
 
-# off1 MongodDB data (on zfs-nvme
---no-sync-snap --no-privilege-elevation off2operator@10.0.0.1:zfs-nvme/pve/subvol-102-disk-0 zfs-hdd/off-backups/mongodb
 # off1 PVE managed volumes
 --no-sync-snap --no-privilege-elevation --recursive off2operator@10.0.0.1:zfs-hdd/pve zfs-hdd/off-backups/off1-pve
 --no-sync-snap --no-privilege-elevation --recursive off2operator@10.0.0.1:zfs-nvme/pve zfs-hdd/off-backups/off1-pve-nvme


### PR DESCRIPTION
mongoDB is inside container 102, already backuped up by other rule
