### PR TITLE
fix: filter config file empty lines in syncoid.service

### DIFF
--- a/confs/common/systemd/system/syncoid.service
+++ b/confs/common/systemd/system/syncoid.service
@@ -15,7 +15,7 @@ Type=oneshot
 # we also handle return result so that we get notified if there is an error.
 # Some tricks: use '$$' for $ for systemd some interpolation 
 # + give syncoid a null input, as otherwise it consumes main input and we do loose commands
-ExecStart=/bin/bash -c 'RESULT=0; grep -v "^#" /etc/sanoid/syncoid-args.conf | while read -a sync_args;do syncoid --quiet "$${sync_args[@]}" </dev/null ; RESULT=$$(($$RESULT + $$?)); done; exit $$RESULT;'
+ExecStart=/bin/bash -c 'RESULT=0; egrep -v "^(#|$)" /etc/sanoid/syncoid-args.conf | while read -a sync_args;do syncoid --quiet "$${sync_args[@]}" </dev/null ; RESULT=$$(($$RESULT + $$?)); done; exit $$RESULT;'
 # place a timeout for bad cases (remote machine shutdown), it's a large timeout
 # note: we have to use TimeoutStartSec as it's a Type=oneshot service
 TimeoutStartSec=6h


### PR DESCRIPTION
### What
syncoid.service does not filter empty line in its arg config file which causes errors in journals
