### PR TITLE
chore: update stunnel conf on ovh1 reverse proxy

### DIFF
--- a/confs/ovh1-reverse-proxy/stunnel/off.conf
+++ b/confs/ovh1-reverse-proxy/stunnel/off.conf
@@ -54,3 +54,18 @@ accept = 10.1.0.101:5503
 connect = 2a06:c484:5::102:5503
 ciphers = PSK
 PSKsecrets = /etc/stunnel/psk/triton-psk.txt
+
+# Likewise, access Triton on osm45 VM 201 (VM with 2 GPUs)
+[Triton-GPU-gRPC]
+client = yes
+accept = 10.1.0.101:5507
+connect = 2a06:c484:5::102:5507
+ciphers = PSK
+PSKsecrets = /etc/stunnel/psk/triton-psk.txt
+
+[Triton-GPU-HTTP]
+client = yes
+accept = 10.1.0.101:5506
+connect = 2a06:c484:5::102:5506
+ciphers = PSK
+PSKsecrets = /etc/stunnel/psk/triton-psk.txt


### PR DESCRIPTION
Allow to reach osm45 VM 201, which hosts Triton with 2 GPUs. This allows Open Prices to run ML models on GPUs.