### PR TITLE
fix: for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - name: Run top issues action


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-infrastructure/security/code-scanning/8](https://github.com/openfoodfacts/openfoodfacts-infrastructure/security/code-scanning/8)

To resolve the problem, explicitly declare a `permissions` block for the workflow or, more granularly, for the specific job that needs to use GITHUB_TOKEN. In this workflow, the action likely only needs to read repository contents and write to issues (to label/toplist issues). Therefore, add a `permissions` key set to `contents: read` and `issues: write` under the `ShowAndLabelTopIssues` job definition at the same level as `runs-on`. This ensures least-privilege principle is applied without impacting workflow functionality. Edit the `.github/workflows/top-issues.yml` file, adding this block while retaining all other job settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
