### PR TITLE
feat: add email-failures systemd service

### DIFF
--- a/ansible/group_vars/pvescaleway/proxmox.yml
+++ b/ansible/group_vars/pvescaleway/proxmox.yml
@@ -21,7 +21,6 @@ pvescaleway_common_proxmox_node__zfs_filesystems:
   # - name: zfs-hdd/backups
   - name: zfs-nvme/pve
 
-
 # storages,
 # we need to declare all of them event if not present on all nodes
 proxmox_node__pve_storages:

--- a/ansible/host_vars/scaleway-02/proxmox.yml
+++ b/ansible/host_vars/scaleway-02/proxmox.yml
@@ -3,7 +3,6 @@ proxmox_node__pve_cluster_addr0: 10.13.0.2
 
 # ZFS pools were created manually. We keep them out of Ansible as they might be modified manually.
 proxmox_node__zfs_pools: []
-
 proxmox_node__zfs_filesystems: "{{ pvescaleway_common_proxmox_node__zfs_filesystems }}"
 
 proxmox_node__pve_storages:

--- a/ansible/jobs/configure.yml
+++ b/ansible/jobs/configure.yml
@@ -16,6 +16,8 @@
       tags: ["firewall", "iptables"]
     - role: fail2ban_iptables
       tags: fail2ban
+    - role: systemd_email_failures
+      tags: ["systemd", "alerts"]
 # TODO
 #    - role: munin-node
 #      tags: [munin, munin-node]

--- a/ansible/roles/systemd_email_failures/README.md
+++ b/ansible/roles/systemd_email_failures/README.md
@@ -1,0 +1,6 @@
+# Systemd email failures
+
+This role install a very simple service named email-failures.
+
+It is called in the OnFailure directive of important services,
+to create a notification if a service fail.

--- a/ansible/roles/systemd_email_failures/files/email-failures@.service
+++ b/ansible/roles/systemd_email_failures/files/email-failures@.service
@@ -1,0 +1,11 @@
+[Unit]
+# call this unit in the OnFailure directive
+# you can use %i if needed, or %l (%H on older systemd versions)
+Description=%i failure email notification on %l
+
+[Service]
+Type=oneshot
+# replace __ by @ in instance name to be able to call status on a specific instance
+# then use mailx to email status (apt install bsd-mailx if needed)
+ExecStart=/bin/bash -c 'HOST_NAME=%H; INSTANCE_NAME=%i; SERVICE_NAME=$${INSTANCE_NAME//__/@}; /bin/systemctl status $$SERVICE_NAME | /usr/bin/mailx -s "[$$HOST_NAME][$$SERVICE_NAME] failure notification" root'
+

--- a/ansible/roles/systemd_email_failures/handlers/main.yml
+++ b/ansible/roles/systemd_email_failures/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: "Reload systemd"
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/ansible/roles/systemd_email_failures/tasks/main.yml
+++ b/ansible/roles/systemd_email_failures/tasks/main.yml
@@ -9,10 +9,4 @@
     src: email-failures@.service
     dest: /etc/systemd/system/email-failures@.service
     mode: "0644"
-  register: _systemd_email_failures__definition
-
-- name: Reload systemd if needed.
-  ansible.builtin.systemd_service:
-    # reload systemd daemon the before applying changes
-    daemon_reload: true
-  when: _systemd_email_failures__definition.changed
+  notify: "systemd_email_failures : Reload systemd"

--- a/ansible/roles/systemd_email_failures/tasks/main.yml
+++ b/ansible/roles/systemd_email_failures/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Install mailx, used by email-failures
+  ansible.builtin.package:
+    name: bsd-mailx
+    state: present
+
+- name: Add email-failures service definition
+  ansible.builtin.copy:
+    src: email-failures@.service
+    dest: /etc/systemd/system/email-failures@.service
+    mode: "0644"
+  register: _systemd_email_failures__definition
+
+- name: Reload systemd if needed.
+  ansible.builtin.systemd_service:
+    # reload systemd daemon the before applying changes
+    daemon_reload: true
+  when: _systemd_email_failures__definition.changed


### PR DESCRIPTION
to base configs.

Very important to get alerts on some services failing.

Run on already deployed servers.
