### PR TITLE
docs: certbot cleanup on ovh proxy

### DIFF
--- a/docs/nginx-reverse-proxy.md
+++ b/docs/nginx-reverse-proxy.md
@@ -336,3 +336,33 @@ Along with nginx, some other tools can be installed:
 
 An ipv6 address was added to the reverse proxy CT, so that the reverse proxy can reach `docker-prod-2` VM on Moji,
 where Robotoff services are running. Moji server is currently only accessible through ipv6 as it does not have a public ipv4 address. See [Moji Datacenter](moji-datacenter.md) and [moji server installation report](reports/2024-08-13-moji-server-installation.md) for more information.
+
+## Certbot debugging tips
+
+**Important**: it's important to keep certbot certificates renewal request in control,
+because Let's Encrypt might temporary ban if we make too much wrong requests.
+
+If we have problems with certbot,
+
+- We can look at `journalctl -xe -u certbot` for errors
+- We can look at `/.well-known/acme-challenge/` traces in logs.
+- We can also launch a `certbot renew --test-cert --dry-run`.
+  Using `--test-cert` do it on a staging server preventing temporary ban.
+
+- To test manually, we can use the same kind of snippet than certbot use,
+  and add it to the config file:
+  ```nginx
+  location = /.well-known/acme-challenge/test1234{
+      default_type text/plain;
+      return 200 test1234;
+  }
+  ```
+  (for example if you want to modify the config so that there is no 401 problem)
+
+Some thing you should check:
+- the DNS is still pointing at this nginx (try a ping to see if ip matches).
+  Having no match of `.well-know/acme-challenge` in the access log can be a good indicator.
+
+certbot also tries to renew certificates that are not linked to a local website anymore.
+You can list active certificates with `certbot certificates`
+and you can remove a specific one with `certbot delete --cert-name <certificate-name>`

--- a/docs/reports/2026-01-19-cleaning-certbot-errors.md
+++ b/docs/reports/2026-01-19-cleaning-certbot-errors.md
@@ -1,0 +1,71 @@
+# 2026-01-19 Cleaning certbot errors on ovh1 reverse proxy
+
+## Problem
+
+We got alerts in the morning because folksonomy API service is down.
+Indeed the service has a certificate problem.
+
+On the reverse proxy,
+`journalctl -xe -u certbot`
+shows us errors.
+
+For alertmanager and other monitoring services, this is because they have been moved to monitoring-01.
+```
+janv. 19 03:11:03 proxy certbot[11030]: Attempting to renew cert (alertmanager.openfoodfacts.org) fr
+janv. 19 03:11:12 proxy certbot[11030]: Attempting to renew cert (annotate.openfoodfacts.net) from /
+janv. 19 03:11:21 proxy certbot[11030]: Attempting to renew cert (annotate.openfoodfacts.org) from /
+janv. 19 03:11:32 proxy certbot[11030]: Attempting to renew cert (api.folksonomy.openfoodfacts.org-0
+janv. 19 03:11:42 proxy certbot[11030]: Attempting to renew cert (api.folksonomy.openfoodfacts.org) 
+janv. 19 03:11:51 proxy certbot[11030]: Attempting to renew cert (auth.openfoodfacts.net) from /etc/
+janv. 19 03:12:01 proxy certbot[11030]: Attempting to renew cert (contents.openfoodfacts.org) from /
+janv. 19 03:12:10 proxy certbot[11030]: Attempting to renew cert (elasticsearch.openfoodfacts.org) f
+janv. 19 03:12:20 proxy certbot[11030]: Attempting to renew cert (facets-kp.openfoodfacts.net) from 
+janv. 19 03:12:29 proxy certbot[11030]: Attempting to renew cert (facets-kp.openfoodfacts.org) from 
+janv. 19 03:12:38 proxy certbot[11030]: Attempting to renew cert (grafana.openfoodfacts.org) from /e
+janv. 19 03:12:48 proxy certbot[11030]: Attempting to renew cert (kibana.openfoodfacts.org) from /et
+janv. 19 03:12:58 proxy certbot[11030]: Attempting to renew cert (link.openfoodfacts.org) from /etc/
+janv. 19 03:13:10 proxy certbot[11030]: Attempting to renew cert (metabase.openfoodfacts.org) from /
+```
+
+There are 404 and 401 problems.
+
+See [Certbot debugging tips](../nginx-reverse-proxy.md#certbot-debugging-tips)
+
+## Removing old monitoring services
+
+Some of the services listed above are part of monitoring and when moved to monitoring-01:
+- alertmanager.openfoodfacts.org
+- elasticsearch.openfoodfacts.org
+- grafana.openfoodfacts.org
+- kibana.openfoodfacts.org
+- monitoring.openfoodfacts.org
+- prometheus.openfoodfacts.org
+
+So I had to:
+- unlink each file in `/etc/nginx/conf.d`
+- remove the corresponding files in the git repository (for clarity)
+- remove certificates:
+  - `certbot certificates` to list them, then
+  - `certbot delete --cert-name <cert-name>` to remove them
+    (generally cert-name is the domain name)
+
+## Removing old certificates
+
+I to remove some certificates that were not used anymore:
+- query.openfoodfacts.org
+- price.openfoodfacts.org (instead of prices)
+- off-wiki.rn7.net
+- openfoodfacts.info
+
+# Fixing the rest
+
+After removing the monitoring sites,
+`certbot renew --test-cert --dry-run`
+seems to show that it will be ok now even for folksonomy.
+So I run the `certbot renew` command and it fixed folksonomy engine certificate problem.
+
+## On off2 reverse proxy
+
+I inspected off2 reverse proxy and found auth.openfoodfacts.org
+which was moved to scaleway,
+so I removed the confs and the certificates.


### PR DESCRIPTION
A certificate non renewal on folksonomy API leads to cleaning certbot certificates on ovh proxy.