### PR TITLE
fix: more private ipv4, to enable querying from docker

### DIFF
--- a/ansible/group_vars/all/common.yml
+++ b/ansible/group_vars/all/common.yml
@@ -37,6 +37,9 @@ off_internal_hosts_ips_v6: |
 off_private_networks_v4:
   # local network
   - "10.0.0.0/8"
+  # network used by docker
+  - "172.16.0.0/12"
+  - "192.168.0.0/16"
 
 # FIXME
 off_private_networks_v6: []

--- a/ansible/host_vars/scaleway-01/sanoid.yml
+++ b/ansible/host_vars/scaleway-01/sanoid.yml
@@ -1,6 +1,5 @@
 ---
 sanoid__datasets_to_create: []
-
 sanoid__create_operators:
   - username: scaleway01operator
     server: off2

--- a/ansible/host_vars/scaleway-02/sanoid.yml
+++ b/ansible/host_vars/scaleway-02/sanoid.yml
@@ -1,6 +1,5 @@
 ---
 sanoid__datasets_to_create: []
-
 sanoid__create_operators:
   - username: scaleway02operator
     server: off1


### PR DESCRIPTION
otherwise it's blocking requests to host.docker.internal, needed for example on monitoring

Note: already played on every hosts.