### PR TITLE
docs: fix letsencrypt links (wrong tar usage)

### DIFF
--- a/docs/reports/2026-03-12-moving-opff-to-scaleway.md
+++ b/docs/reports/2026-03-12-moving-opff-to-scaleway.md
@@ -287,15 +287,16 @@ On off2-proxy:
 CONF=/etc/nginx/sites-enabled/openpetfoodfacts.org
 DOM=$(sed -nr  "s|.*letsencrypt/live/(.*)/privkey.*|\1|p" $CONF)
 echo "COPYING CERTS FOR $DOM in $DOM.tar.gz"
-sudo tar -chvzf $DOM.tar.gz \
+sudo tar -cvzf $DOM.tar.gz \
     /etc/letsencrypt/archive/${DOM} \
     /etc/letsencrypt/renewal/${DOM}.conf \
     /etc/letsencrypt/live/${DOM}
 sudo chown alex:alex $DOM.tar.gz
 sudo chmod go-rw $DOM.tar.gz
 ```
+
 I then copied it to scaleway-proxy (using scp).
-And on scaleway-proxy:
+And on scaleway-proxy[^ErrorTarLetsencrypt]:
 ```bash
 cd /
 tar xzf /home/alex/openpetfoodfacts.org.tar.gz
@@ -326,7 +327,24 @@ I also edited openfoodfacts.org conf
 * comment stapple directive (deprecated)
 * to substitute any occurrence of `10.1.0.118` for `10.13.1.115`.
 
-
+[^ErrorTarLetsencrypt]: When I did it, in fact I did use the -h flag
+  which dereferences symlink, and certbot is not happy with it
+  (`live` items must points to `archive` items).
+  To fix that, I had to use this command:
+  ```bash
+  FOLDER=openpetfoodfacts.org; \
+  for f in /etc/letsencrypt/live/$FOLDER/*.*; \
+  do \
+    NAME=$(basename $f); \
+    BARE_NAME=${NAME%.*}; \
+    TARGET=$(ls -tr /etc/letsencrypt/archive/$FOLDER/${BARE_NAME}*|tail -n 1); \
+    TARGET_FILE=$(basename $TARGET); \
+    unlink $f; \
+    ln -s ../../archive/$FOLDER/$TARGET_FILE $f; \
+  done
+  ls -l /etc/letsencrypt/live/$FOLDER
+  ```
+  then verify with `nginx -t`
 
 ## Testing
 

--- a/docs/reports/2026-03-27-moving-obf-opf-to-scaleway.md
+++ b/docs/reports/2026-03-27-moving-obf-opf-to-scaleway.md
@@ -47,7 +47,7 @@ On off2-proxy:
 CONF=/etc/nginx/sites-enabled/openbeautyfacts.org
 DOM=$(sed -nr  "s|.*letsencrypt/live/(.*)/privkey.*|\1|p" $CONF)
 echo "COPYING CERTS FOR $DOM in $DOM.tar.gz"
-sudo tar -chvzf $DOM.tar.gz \
+sudo tar -cvzf $DOM.tar.gz \
     /etc/letsencrypt/archive/${DOM} \
     /etc/letsencrypt/renewal/${DOM}.conf \
     /etc/letsencrypt/live/${DOM}
@@ -55,7 +55,7 @@ sudo chown alex:alex $DOM.tar.gz
 sudo chmod go-rw $DOM.tar.gz
 ```
 I then copied it to scaleway-proxy (using scp).
-And on scaleway-proxy:
+And on scaleway-proxy[^ErrorTarLetsencrypt]:
 ```bash
 cd /
 tar xzf /home/alex/openbeautyfacts.org.tar.gz
@@ -77,6 +77,24 @@ I also edited openbeautyfacts.org conf
 * comment `ssl_stapling` and `ssl_stapling_verify` directives (deprecated)
 * to substitute any occurrence of `10.1.0.116` for `10.13.1.113`.
 
+[^ErrorTarLetsencrypt]: When I did it, in fact I did use the -h flag
+  which dereferences symlink, and certbot is not happy with it
+  (`live` items must points to `archive` items).
+  To fix that, I had to use this command:
+  ```bash
+  FOLDER=openbeautyfacts.org; \
+  for f in /etc/letsencrypt/live/$FOLDER/*.*; \
+  do \
+    NAME=$(basename $f); \
+    BARE_NAME=${NAME%.*}; \
+    TARGET=$(ls -tr /etc/letsencrypt/archive/$FOLDER/${BARE_NAME}*|tail -n 1); \
+    TARGET_FILE=$(basename $TARGET); \
+    unlink $f; \
+    ln -s ../../archive/$FOLDER/$TARGET_FILE $f; \
+  done
+  ls -l /etc/letsencrypt/live/$FOLDER
+  ```
+  then verify with `nginx -t`
 
 ### Preparing DNS
 
@@ -227,7 +245,7 @@ On off2-proxy:
 CONF=/etc/nginx/sites-enabled/openproductsfacts.org
 DOM=$(sed -nr  "s|.*letsencrypt/live/(.*)/privkey.*|\1|p" $CONF)
 echo "COPYING CERTS FOR $DOM in $DOM.tar.gz"
-sudo tar -chvzf $DOM.tar.gz \
+sudo tar -cvzf $DOM.tar.gz \
     /etc/letsencrypt/archive/${DOM} \
     /etc/letsencrypt/renewal/${DOM}.conf \
     /etc/letsencrypt/live/${DOM}
@@ -235,7 +253,7 @@ sudo chown alex:alex $DOM.tar.gz
 sudo chmod go-rw $DOM.tar.gz
 ```
 I then copied it to scaleway-proxy (using scp).
-And on scaleway-proxy:
+And on scaleway-proxy[^ErrorTarLetsencrypt]:
 ```bash
 cd /
 tar xzf /home/alex/openproductsfacts.org.tar.gz
@@ -256,6 +274,25 @@ I also edited openproductsfacts.org conf
 * `listen 443 ... http2` is now deprecated in favour of `http2 on;`
 * comment `ssl_stapling` and `ssl_stapling_verify` directives (deprecated)
 * to substitute any occurrence of `10.1.0.117` for `10.13.1.114`.
+
+[^ErrorTarLetsencrypt]: When I did it, in fact I did use the -h flag
+  which dereferences symlink, and certbot is not happy with it
+  (`live` items must points to `archive` items).
+  To fix that, I had to use this command:
+  ```bash
+  FOLDER=openproductsfacts.org; \
+  for f in /etc/letsencrypt/live/$FOLDER/*.*; \
+  do \
+    NAME=$(basename $f); \
+    BARE_NAME=${NAME%.*}; \
+    TARGET=$(ls -tr /etc/letsencrypt/archive/$FOLDER/${BARE_NAME}*|tail -n 1); \
+    TARGET_FILE=$(basename $TARGET); \
+    unlink $f; \
+    ln -s ../../archive/$FOLDER/$TARGET_FILE $f; \
+  done
+  ls -l /etc/letsencrypt/live/$FOLDER
+  ```
+  then verify with `nginx -t`
 
 
 ### Preparing DNS

--- a/docs/reports/2026-04-01-moving-open-prices-to-scaleway-03.md
+++ b/docs/reports/2026-04-01-moving-open-prices-to-scaleway-03.md
@@ -268,7 +268,7 @@ On ovh1-proxy:
 CONF=/etc/nginx/conf.d/prices.openfoodfacts.org
 DOM=$(sed -nr  "s|.*letsencrypt/live/(.*)/privkey.*|\1|p" $CONF)
 echo "COPYING CERTS FOR $DOM in $DOM.tar.gz"
-sudo tar -chvzf $DOM.tar.gz \
+sudo tar -cvzf $DOM.tar.gz \
     /etc/letsencrypt/archive/${DOM} \
     /etc/letsencrypt/renewal/${DOM}.conf \
     /etc/letsencrypt/live/${DOM}
@@ -276,7 +276,7 @@ sudo chmod go-rw $DOM.tar.gz
 ```
 
 I then copied it to scaleway-proxy (using scp).
-On scaleway-proxy:
+On scaleway-proxy[^ErrorTarLetsencrypt]:
 
 ```bash
 cd /
@@ -286,6 +286,25 @@ ls -l /etc/letsencrypt/*/prices.openfoodfacts.org /etc/letsencrypt/renewal/price
 ```
 
 I also copied the Open Prices nginx configuration from ovh1-proxy to scaleway-proxy, updating the proxy_pass to point to scaleway-docker-prod-2 internal IP address.
+
+[^ErrorTarLetsencrypt]: When I did it, in fact I did use the -h flag
+  which dereferences symlink, and certbot is not happy with it
+  (`live` items must points to `archive` items).
+  To fix that, I had to use this command:
+  ```bash
+  FOLDER=prices.openfoodfacts.org; \
+  for f in /etc/letsencrypt/live/$FOLDER/*.*; \
+  do \
+    NAME=$(basename $f); \
+    BARE_NAME=${NAME%.*}; \
+    TARGET=$(ls -tr /etc/letsencrypt/archive/$FOLDER/${BARE_NAME}*|tail -n 1); \
+    TARGET_FILE=$(basename $TARGET); \
+    unlink $f; \
+    ln -s ../../archive/$FOLDER/$TARGET_FILE $f; \
+  done
+  ls -l /etc/letsencrypt/live/$FOLDER
+  ```
+  then verify with `nginx -t`
 
 ## Copying data from ovh to scaleway
 


### PR DESCRIPTION
I did fix an error today due to the way we migrated letsencrypt files from off2 proxy to scaleway proxy.