### PR TITLE
feat: expose prometheus health status

### DIFF
--- a/ansible/host_vars/monitoring-01/reverse-proxy.yml
+++ b/ansible/host_vars/monitoring-01/reverse-proxy.yml
@@ -9,6 +9,9 @@ reverse_proxy_docker__websites:
     proxy_pass: "prometheus:9090"
     username: "off"
     password: "{{ password_monitoring_sites }}"
+    public_paths:
+      # enable external monitoring of prometheus state !
+      - "/-/healthy"
 
   - url: "monitoring.openfoodfacts.org"
     proxy_pass: "grafana:3000"

--- a/ansible/roles/continuous_deployment/tasks/main.yml
+++ b/ansible/roles/continuous_deployment/tasks/main.yml
@@ -29,7 +29,7 @@
     create_home: true
     shell: /usr/sbin/nologin
     password: "!" # ie no password / no login
-  delegate_to: "{{ continuous_deployment__proxy_jump_host }}"
+  delegate_to: "{{ continuous_deployment__proxy_jump_host or 'localhost' }}"
   when: continuous_deployment__proxy_jump_host | default(False)
 
 - name: Ensures all SSH public keys are present for deployers on jump proxy
@@ -37,5 +37,5 @@
     user: "{{ continuous_deployment__user }}"
     key: "{{ continuous_deployment__ssh_public_keys | join('\n') }}"
     exclusive: false # there might be other proxy jump needed
-  delegate_to: "{{ continuous_deployment__proxy_jump_host }}"
+  delegate_to: "{{ continuous_deployment__proxy_jump_host or 'localhost' }}"
   when: continuous_deployment__proxy_jump_host | default(False)

--- a/ansible/roles/reverse_proxy_docker/README.md
+++ b/ansible/roles/reverse_proxy_docker/README.md
@@ -17,17 +17,18 @@ reverse_proxy_docker__websites:
     proxy_pass: "example2-webserver:80"
     username: "off" # optional
     password: "{{ secrets_off_password }}" # optional
+    public_path: ["/a-public/path"]
 
-reverse_proxy_https_cert_domains:
+https_cert_domains:
   - "openfoodfacts.org" # that's actually the default
 ```
 
 In `host_vars/<node_name>/reverse-proxy-secrets.yml`, create a variable with the following shape:
 
 ```yml
-reverse_proxy_certbot_ovh_application_key: "[...]"
-reverse_proxy_certbot_ovh_application_secret: "[...]"
-reverse_proxy_certbot_ovh_consumer_key: "[...]"
+certbot_ovh_application_key: "[...]"
+certbot_ovh_application_secret: "[...]"
+certbot_ovh_consumer_key: "[...]"
 ```
 
 In this example, the task will create a `nginx` configuration that passes:
@@ -49,7 +50,7 @@ I recommend to choose a randomly-generated 21 characters password from the `a-zA
 
 #### HTTPS Certificates
 
-The `reverse_proxy_https_cert_domains` variable will create a wildcard https certificate for the domains in this list (it defaults to `["openfoodfacts.org"]`).
+The `https_cert_domains` variable will create a wildcard https certificate for the domains in this list (it defaults to `["openfoodfacts.org"]`).
 
 To generate those certificates, we use a DNS challenge and the OVH API. See [docs/nginx-reverse-proxy.md How to add wildcard certificates](../../../docs/nginx-reverse-proxy.md) on how to generate them, and put the credentials in the variables stated above.
 
@@ -67,16 +68,16 @@ services:
     build: .
     restart: unless-stopped
     networks:
-      - reverse_proxy_network
+      - network
 
 networks:
-  reverse_proxy_network:
+  network:
     external: true
 ```
 
-Adding the `reverse_proxy_network` allows the reverse proxy and the webserver to communicate.
+Adding the `network` allows the reverse proxy and the webserver to communicate.
 
-⚠️ You should **NOT** use `ports:` in the docker compose, this network should be enough. Moreover, only apply the `reverse_proxy_network` to services that need access to internet. For exemple, a database only used locally shouldn't be connected to `reverse_proxy_network`.
+⚠️ You should **NOT** use `ports:` in the docker compose, this network should be enough. Moreover, only apply the `network` to services that need access to internet. For exemple, a database only used locally shouldn't be connected to `reverse_proxy_docker__network`.
 
 #### When the reverse proxy and the webserver are NOT on the same host
 

--- a/ansible/roles/reverse_proxy_docker/README.md
+++ b/ansible/roles/reverse_proxy_docker/README.md
@@ -19,16 +19,16 @@ reverse_proxy_docker__websites:
     password: "{{ secrets_off_password }}" # optional
     public_path: ["/a-public/path"]
 
-https_cert_domains:
+reverse_proxy_docker__https_cert_domains:
   - "openfoodfacts.org" # that's actually the default
 ```
 
 In `host_vars/<node_name>/reverse-proxy-secrets.yml`, create a variable with the following shape:
 
 ```yml
-certbot_ovh_application_key: "[...]"
-certbot_ovh_application_secret: "[...]"
-certbot_ovh_consumer_key: "[...]"
+reverse_proxy_docker__certbot_ovh_application_key: "[...]"
+reverse_proxy_docker__certbot_ovh_application_secret: "[...]"
+reverse_proxy_docker__certbot_ovh_consumer_key: "[...]"
 ```
 
 In this example, the task will create a `nginx` configuration that passes:
@@ -50,7 +50,7 @@ I recommend to choose a randomly-generated 21 characters password from the `a-zA
 
 #### HTTPS Certificates
 
-The `https_cert_domains` variable will create a wildcard https certificate for the domains in this list (it defaults to `["openfoodfacts.org"]`).
+The `reverse_proxy_docker__https_cert_domains` variable will create a wildcard https certificate for the domains in this list (it defaults to `["openfoodfacts.org"]`).
 
 To generate those certificates, we use a DNS challenge and the OVH API. See [docs/nginx-reverse-proxy.md How to add wildcard certificates](../../../docs/nginx-reverse-proxy.md) on how to generate them, and put the credentials in the variables stated above.
 
@@ -68,16 +68,16 @@ services:
     build: .
     restart: unless-stopped
     networks:
-      - network
+      - reverse_proxy_network
 
 networks:
-  network:
+  reverse_proxy_network:
     external: true
 ```
 
-Adding the `network` allows the reverse proxy and the webserver to communicate.
+Adding the `reverse_proxy_network` allows the reverse proxy and the webserver to communicate.
 
-⚠️ You should **NOT** use `ports:` in the docker compose, this network should be enough. Moreover, only apply the `network` to services that need access to internet. For exemple, a database only used locally shouldn't be connected to `reverse_proxy_docker__network`.
+⚠️ You should **NOT** use `ports:` in the docker compose, this network should be enough. Moreover, only apply the `reverse_proxy_network` to services that need access to internet. For exemple, a database only used locally shouldn't be connected to `reverse_proxy_network`.
 
 #### When the reverse proxy and the webserver are NOT on the same host
 

--- a/ansible/roles/reverse_proxy_docker/defaults/main/reverse-proxy.yml
+++ b/ansible/roles/reverse_proxy_docker/defaults/main/reverse-proxy.yml
@@ -2,7 +2,13 @@
 reverse_proxy_docker__dir: "/opt/reverse_proxy"
 reverse_proxy_docker__user: "reverse-proxy"
 
+# the websites as a list of dicts
 reverse_proxy_docker__websites: []
+#  - url: <server_name>
+#    proxy_pass: <the address to reach>
+#    username: <basic auth username>
+#    password: <basic auth password>  # only if set is basic_auth applied
+#    public_paths: [<public path, as a nginx map expression>, …] # they do not require basic auth
 reverse_proxy_docker__https_cert_domains:
   - "openfoodfacts.org"
 

--- a/ansible/roles/reverse_proxy_docker/files/docker-compose.yml
+++ b/ansible/roles/reverse_proxy_docker/files/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       # used to transfer certificates with certbot
       - ./certbot/conf/:/etc/nginx/ssl/:ro
     networks:
-      - reverse_proxy_docker__network
-      - reverse_proxy_docker__internal
+      - reverse_proxy_network
+      - reverse_proxy_internal
 
   certbot:
     image: certbot/dns-ovh:v4.0.0
@@ -31,8 +31,8 @@ services:
 networks:
   # this is where we expose services that needs to be accessible to nginx
   # but not directly to the internet
-  reverse_proxy_docker__internal:
-    name: reverse_proxy_docker__internal
-  reverse_proxy_docker__network:
-    name: reverse_proxy_docker__network
+  reverse_proxy_internal:
+    name: reverse_proxy_internal
+  reverse_proxy_network:
+    name: reverse_proxy_network
     driver: bridge

--- a/ansible/roles/reverse_proxy_docker/tasks/nginx.yml
+++ b/ansible/roles/reverse_proxy_docker/tasks/nginx.yml
@@ -25,13 +25,13 @@
   ansible.builtin.find:
     paths: "{{ reverse_proxy_docker__dir }}/nginx/passwords"
     file_type: file
-  register: _reverse_proxy_docker_found_files
+  register: _reverse_proxy_docker__found_files
 
 - name: Delete password files that are not used anymore
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
-  loop: "{{ _reverse_proxy_docker_found_files.files | rejectattr('path', 'in', active_names) | list }}"
+  loop: "{{ _reverse_proxy_docker__found_files.files | rejectattr('path', 'in', active_names) | list }}"
   loop_control:
     label: "{{ item.path }}"
   vars:

--- a/ansible/roles/reverse_proxy_docker/templates/certbot/certbot-renew.sh
+++ b/ansible/roles/reverse_proxy_docker/templates/certbot/certbot-renew.sh
@@ -14,7 +14,7 @@ certbot certonly \
     --dns-ovh \
     --dns-ovh-credentials /config/ovh.ini \
     -m "{{ secrets_infra_email }}" \
-{% for domain in reverse_proxy_https_cert_domains %}
+{% for domain in reverse_proxy_docker__https_cert_domains %}
     -d "{{ domain }}" \
     -d "*.{{ domain }}" \
 {% endfor %}

--- a/ansible/roles/reverse_proxy_docker/templates/certbot/cron-start-certbot.sh
+++ b/ansible/roles/reverse_proxy_docker/templates/certbot/cron-start-certbot.sh
@@ -4,7 +4,7 @@
 # it starts the 'certbot' container, which starts the 'templates/certbot/certbot-renew.sh' script
 # the container then stops
 
-cd {{ reverse_proxy_dir }}
+cd {{ reverse_proxy_docker__dir }}
 
 docker compose up certbot --timestamps
 docker compose exec reverse_proxy nginx -s reload

--- a/ansible/roles/reverse_proxy_docker/templates/certbot/ovh.ini
+++ b/ansible/roles/reverse_proxy_docker/templates/certbot/ovh.ini
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-dns_ovh_endpoint = {{ reverse_proxy_certbot_ovh_endpoint }}
-dns_ovh_application_key = {{ reverse_proxy_certbot_ovh_application_key }}
-dns_ovh_application_secret = {{ reverse_proxy_certbot_ovh_application_secret }}
-dns_ovh_consumer_key = {{ reverse_proxy_certbot_ovh_consumer_key }}
+dns_ovh_endpoint = {{ reverse_proxy_docker__certbot_ovh_endpoint }}
+dns_ovh_application_key = {{ reverse_proxy_docker__certbot_ovh_application_key }}
+dns_ovh_application_secret = {{ reverse_proxy_docker__certbot_ovh_application_secret }}
+dns_ovh_consumer_key = {{ reverse_proxy_docker__certbot_ovh_consumer_key }}

--- a/ansible/roles/reverse_proxy_docker/templates/nginx/sites.conf
+++ b/ansible/roles/reverse_proxy_docker/templates/nginx/sites.conf
@@ -3,7 +3,18 @@
 
 {% for site in reverse_proxy_docker__websites %}
 
+{% set dashed_name = (site.url | replace(".", "_")) %}
 # ============ {{ site.url }} ============
+
+{% if (site.public_paths|default([])) %}
+# exclude some url from basic auth
+map $uri ${{ dashed_name }}_basic_auth {
+  default "{{ site.url }}";
+{% for public_path in site.public_paths %}
+  {{ public_path }} "off";
+{% endfor %}
+}
+{% endif %}
 
 server {
     listen 443 ssl;
@@ -22,7 +33,11 @@ server {
     }
 
 {% if site.password is defined %}
+  {% if (site.public_paths|default([])) %}
+        auth_basic ${{ dashed_name }}_basic_auth;
+  {% else %}
         auth_basic "{{ site.url }}";
+  {% endif %}
         auth_basic_user_file /etc/nginx/passwords/{{ site.url }};
 {% endif %}
 
@@ -59,3 +74,4 @@ server {
         return 301 https://$host$request_uri;
     }
 }
+


### PR DESCRIPTION
so that it can be monitored by other tools (monitor the monitoring tool !) without knowing password
Also fix various bug due to reverse_proxy_docker role renaming

Note: already run to configure monitoring-01.
Now https://prometheus.openfoodfacts.org/-/healthy is public.