### PR TITLE
feat: nginx mainline repository

### DIFF
--- a/ansible/roles/reverse_proxy_nginx/tasks/certbot_ovh_dns.yml
+++ b/ansible/roles/reverse_proxy_nginx/tasks/certbot_ovh_dns.yml
@@ -1,11 +1,3 @@
-- name: Get certbot version
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      certbot --version|grep -Po "(\d+\.?)+"
-  changed_when: false
-  register: _reverse_proxy_nginx__certbot_version
-
 - name: Install pip at system level if needed
   ansible.builtin.apt:
     pkg:
@@ -14,6 +6,7 @@
 
 - name: Get certbot version
   ansible.builtin.shell:
+    executable: /bin/bash
     cmd: |
       set -o pipefail
       certbot --version|grep -Po "(\d+\.?)+"

--- a/ansible/roles/reverse_proxy_nginx/tasks/main.yml
+++ b/ansible/roles/reverse_proxy_nginx/tasks/main.yml
@@ -6,7 +6,7 @@
     components: nginx
     name: nginx
     uris: https://nginx.org/packages/mainline/debian
-    suites: "{{ ansible_lsb.codename }}"
+    suites: "{{ ansible_facts['lsb'].codename }}"
     trusted: true
     enabled: true
     signed_by: https://nginx.org/keys/nginx_signing.key
@@ -18,6 +18,37 @@
       - python3-certbot-nginx
     state: present
     update_cache: true
+
+# adopt debian pattern
+- name: Ensure sites-enabled directory exists
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Add conf file for sites-enabled inclusion
+  ansible.builtin.copy:
+    # use zz- prefix to ensure it's the last to be loaded
+    dest: /etc/nginx/conf.d/zz-sites-enabled.conf
+    content: |
+      # WARNING: handled by ansible, do not change manually
+      # Include all config files from sites-enabled directory
+      include /etc/nginx/sites-enabled/*;
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reverse_proxy_nginx__reload_nginx
+
+# base debian and nginx mainline does not use the same user
+- name: Ensure permissions swap from www-data to nginx
+  ansible.builtin.command:
+    # we also have /dev/shm because it is common to have cache there
+    cmd: chown nginx -v --from www-data -R /var/cache/nginx /var/www /dev/shm
+  register: _reverse_proxy_nginx__chown
+  changed_when: "'changed ownership' in _reverse_proxy_nginx__chown.stdout"
 
 - name: Install certbot ovh dns plugin
   ansible.builtin.import_tasks:

--- a/ansible/roles/reverse_proxy_nginx/tasks/main.yml
+++ b/ansible/roles/reverse_proxy_nginx/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+
+- name: Add the nginx apt repository to get latest updates
+  ansible.builtin.deb822_repository:
+    allow_insecure: false
+    components: nginx
+    name: nginx
+    uris: https://nginx.org/packages/mainline/debian
+    suites: "{{ ansible_lsb.codename }}"
+    trusted: true
+    enabled: true
+    signed_by: https://nginx.org/keys/nginx_signing.key
+
 - name: Install nginx and certbot from distribution
   ansible.builtin.apt:
     pkg:

--- a/ansible/roles/reverse_proxy_nginx/tasks/prometheus_exporter.yml
+++ b/ansible/roles/reverse_proxy_nginx/tasks/prometheus_exporter.yml
@@ -11,4 +11,4 @@
     src: stub_status
     mode: "0644"
   notify:
-    - reverse_proxy_nginx__reload_nginx
+    - Reverse_proxy_nginx__reload_nginx


### PR DESCRIPTION
Install nginx from the official nginx repository, getting far more updates.