### PR TITLE
chore: add Paddlex service on docker-prod-2 (osm45)

### DIFF
--- a/docker/paddlex/conf/OCR.yaml
+++ b/docker/paddlex/conf/OCR.yaml
@@ -1,0 +1,47 @@
+# This is the default OCR configuration of PaddleX, except that
+# we decreased max_side_limit to 1200, to speed up OCR processing
+pipeline_name: OCR
+
+text_type: general
+
+use_doc_preprocessor: True
+use_textline_orientation: True
+
+SubPipelines:
+  DocPreprocessor:
+    pipeline_name: doc_preprocessor
+    use_doc_orientation_classify: True
+    use_doc_unwarping: True
+    SubModules:
+      DocOrientationClassify:
+        module_name: doc_text_orientation
+        model_name: PP-LCNet_x1_0_doc_ori
+        model_dir: null
+      DocUnwarping:
+        module_name: image_unwarping
+        model_name: UVDoc
+        model_dir: null
+
+SubModules:
+  TextDetection:
+    module_name: text_detection
+    box_thresh: 0.6
+    limit_side_len: 64
+    limit_type: min
+    model_dir: null # Replace with the path to your fine-tuned text detection model weights
+    model_name: PP-OCRv5_server_det # If the name of the fine-tuned model is different from the default model name, please modify it here as well
+    # max_side_limit was decreased from 4000 to 1200
+    max_side_limit: 1200
+    thresh: 0.3
+    unclip_ratio: 1.5
+  TextLineOrientation:
+    module_name: textline_orientation
+    model_name: PP-LCNet_x1_0_textline_ori
+    model_dir: null
+    batch_size: 6
+  TextRecognition:
+    module_name: text_recognition
+    model_name: PP-OCRv5_server_rec
+    model_dir: null
+    batch_size: 6
+    score_thresh: 0.0

--- a/docker/paddlex/docker-compose.yml
+++ b/docker/paddlex/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  paddlex:
+    restart: always
+    # This image was built by Open Food Facts and pushed to Docker Hub.
+    # see
+    # https://github.com/openfoodfacts/openfoodfacts-infrastructure/blob/develop/docs/reports/2026-06-02-install-paddlex.md
+    image: openfoodfacts/paddlex-ocr:paddlex3.3.11-paddlepaddle3.2.0-cpu
+    volumes:
+      - ./conf/OCR.yaml:/root/PaddleX/paddlex/configs/pipelines/OCR.yaml
+      - ./ocr_models:/root/.paddlex/official_models
+    command: ["paddlex", "--serve", "--pipeline", "OCR"]
+    ports:
+      - "5610:8080"

--- a/docs/reports/2026-06-02-install-paddlex.md
+++ b/docs/reports/2026-06-02-install-paddlex.md
@@ -1,0 +1,59 @@
+# 2026-06-02 Install PaddleX on osm45 (docker-prod-2)
+
+To anonymize receipt on Open Prices, we chose to detect personal information using a LVLM (large visual language model), as these model provide very performant and context-aware PII detection. However, LVLMs are still not very good at localizing exactly where the PII is located on the image.
+We chose the following approach:
+
+1. Use a LVLM to detect PII (as text) on the image
+2. Use a PaddleX model to perform OCR and get each word's bounding box coordinates.
+3. Localize the PII on the image using the bounding box coordinates.
+
+Not many open source solution exist to perform traditional OCR: Tesseract and PaddleOCR.
+
+We chose PaddleOCR, as it provides better performance out of the box than Tesseract.
+
+We need an inference service to run PaddleOCR. The recommended way is to use PaddleX, Baidu inference service.
+
+## Creating the docker image
+
+Baidu provides a [PaddleX docker image](https://paddlepaddle.github.io/PaddleX/latest/en/installation/installation.html#21-get-paddlex-via-docker) for CPU or GPU, available on their own Docker registry.
+We first pull it (CPU version here):
+
+```bash
+docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/paddlex:paddlex3.3.11-paddlepaddle3.2.0-cpu
+```
+
+We then need to modify the image to add the PaddleX serving plugin. First, launch the container:
+
+```bash
+docker run --name paddlex-install -it ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/paddlex:paddlex3.3.11-paddlepaddle3.2.0-cpu /bin/bash
+```
+
+Then run:
+
+```
+paddlex --install serving
+```
+
+Exit the container (`exit`), and commit the changes to the image, under the name `openfoodfacts/paddlex-ocr`:
+
+```bash
+docker commit paddlex-install openfoodfacts/paddlex-ocr:paddlex3.3.11-paddlepaddle3.2.0-cpu
+```
+
+You can then push the image to the Docker registry:
+
+```bash
+docker push openfoodfacts/paddlex-ocr:paddlex3.3.11-paddlepaddle3.2.0-cpu
+```
+
+You can then pull and run the image:
+
+```bash
+docker run -v paddlex-models:/root/.paddlex/official_models --shm-size=8g -it paddlex:paddlex3.3.11-paddlepaddle3.2.0-cpu /bin/bash
+```
+
+
+## Deploying on docker-prod-2
+
+In `/home/off`, a `paddlex` symlink was created to `/opt/openfoodfacts-infrastructure/docker/paddlex`.
+Then, `docker compose up -d` was run to start the service.


### PR DESCRIPTION
This OCR service is necessary to perform receipt anonymization on Open Prices.
I chose `docker-prod-2` VM as it has plenty of CPU cores since we moved Triton to a GPU server.