### PR TITLE
fix: add 'ciphers = PSK' before the PSKsecrets line

### DIFF
--- a/confs/scaleway-stunnel-client/stunnel/off.conf
+++ b/confs/scaleway-stunnel-client/stunnel/off.conf
@@ -38,6 +38,7 @@ client = yes
 # BEWARE: as we have a public ipv6, only accept on private ipv4
 accept = 10.13.1.101:16001
 connect = 2a06:c484:5::102:16001
+ciphers = PSK
 PSKsecrets = /etc/stunnel/psk/moji-off-query-psk.txt
 
 # PaddleX is used by Open Prices to perform OCR

--- a/confs/scaleway-stunnel-client/stunnel/off.conf
+++ b/confs/scaleway-stunnel-client/stunnel/off.conf
@@ -47,4 +47,5 @@ client = yes
 accept = 10.13.1.101:5610
 # target: docker-prod-2 (osm45)
 connect = 2a06:c484:5::102:5610
+ciphers = PSK
 PSKsecrets = /etc/stunnel/psk/paddlex-psk.txt


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/openfoodfacts/openfoodfacts-infrastructure/security/quality/ai-findings)._
The [MojiOffQuery] service is missing the 'ciphers = PSK' directive that is present in other PSK-based services (Triton-HTTP, Triton-gRPC). For consistency and to ensure PSK cipher usage, add 'ciphers = PSK' before the PSKsecrets line.

<img width="423" height="229" alt="image" src="https://github.com/user-attachments/assets/35f676b4-8f5a-433c-acad-661d175eb6f9" />
