### PR TITLE
docs: roles docs must have 'role' in their title

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
-      - name: Checks
-        run: |
-          make check_docs
       - name: Generate documentation
         run: |
           make build_docs

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,11 @@ SHELL := /bin/bash
 # Checks     #
 #------------#
 
-checks: check_docs check_build_docs
-
-check_docs:
-	@echo "🥫 Checking documentation …"
-	@WRONG_EXT=$$(find docs docs/reports -maxdepth 1 -type f|grep -v ".md$$"| grep -v "/.pages$$"); \
-	if [[ -n "$${WRONG_EXT}" ]] ; then echo >&2 "File with wrong extensions $${WRONG_EXT}"; exit 1; fi
+checks: check_build_docs
 
 check_build_docs:
 	@echo "🥫 Building documentation to check it …"
 	@./scripts/build_mkdocs.sh --check
-
 
 build_docs:
 	@echo "🥫 Building documentation …"

--- a/ansible/roles/folksonomy_api/README.md
+++ b/ansible/roles/folksonomy_api/README.md
@@ -1,3 +1,3 @@
-# Folksonmy engine deployment
+# Folksonmy engine deployment role
 
 This role deploy folksonomy engine on a container.

--- a/ansible/roles/git_based_configs/README.md
+++ b/ansible/roles/git_based_configs/README.md
@@ -1,4 +1,4 @@
-# Git based configuration
+# Git based configuration role
 
 This role is used to checkout the git repository on a server,
 so that we can link configurations where needed.

--- a/ansible/roles/iptables/README.md
+++ b/ansible/roles/iptables/README.md
@@ -1,4 +1,4 @@
-# Firewall using iptables rules
+# Firewall using iptables rules role
 
 This is a simple role to install iptables and iptables persistent.
 Configure rules with a few options.

--- a/ansible/roles/postgresql/README.md
+++ b/ansible/roles/postgresql/README.md
@@ -1,4 +1,4 @@
-# PostgreSQL install
+# PostgreSQL install role
 
 This postgreSQL role, install PostgresSQL
 using debian packages from postgres official APT repository.

--- a/ansible/roles/proxmox_containers/README.md
+++ b/ansible/roles/proxmox_containers/README.md
@@ -1,4 +1,4 @@
-# Proxmox Containers management
+# Proxmox Containers management role
 
 This roles handles containers and VM creations.
 

--- a/ansible/roles/pull_pve_configs/README.md
+++ b/ansible/roles/pull_pve_configs/README.md
@@ -1,4 +1,4 @@
-# Pull PVE Configs
+# Pull PVE Configs role
 
 This role pulls pve config using the pseudo filesystem at /etc/pve.
 

--- a/ansible/roles/sftp/README.md
+++ b/ansible/roles/sftp/README.md
@@ -1,4 +1,4 @@
-# SFTP
+# SFTP role
 
 This roles setup a sftp server.
 

--- a/ansible/roles/systemd_email_failures/README.md
+++ b/ansible/roles/systemd_email_failures/README.md
@@ -1,4 +1,4 @@
-# Systemd email failures
+# Systemd email failures role
 
 This role install a very simple service named email-failures.
 

--- a/ansible/roles/virtiofs/README.md
+++ b/ansible/roles/virtiofs/README.md
@@ -1,4 +1,4 @@
-# Virtiofs
+# Virtiofs role
 
 Setup the virtiofs daemon and directory mappings.
 

--- a/ansible/roles/virtiofs_mounts/README.md
+++ b/ansible/roles/virtiofs_mounts/README.md
@@ -1,3 +1,3 @@
-# Virtiofs mounts
+# Virtiofs mounts role
 
 A small role to add Virtiofs mounts in a VM

--- a/scripts/build_mkdocs.sh
+++ b/scripts/build_mkdocs.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# first some sanity checks
+WRONG_EXT=$(find docs docs/reports -maxdepth 1 -type f|grep -v ".md$"| grep -v "/.pages$");
+if [[ -n "${WRONG_EXT}" ]]
+then
+  echo >&2 "File with wrong extensions $${WRONG_EXT}"
+  exit 1
+fi
+MISSING_ROLE_IN_TITLE=$(for f in ansible/roles/*/README.md; do head -n 1 $f|grep --quiet -i role || echo -n $f" ";done)
+if [[ -n "${MISSING_ROLE_IN_TITLE}" ]]
+then
+  echo >&2 'Some roles readme do not have "role" in their title:' ${MISSING_ROLE_IN_TITLE}
+  exit 1
+fi
+
+
 # Renders markdown doc in docs to html in gh_pages
 
 # add documentation for ansible roles


### PR DESCRIPTION
to ease search in online documentation (so that you see *Virtiofs* for the Virtiofs page
and *Virtiofs role* for the role docs).