### PR TITLE
fix(nginx): enable HTTP/2 for static .net assets

### DIFF
--- a/confs/ovh1-reverse-proxy/nginx/sites-enabled/static.openfoodfacts.net.conf
+++ b/confs/ovh1-reverse-proxy/nginx/sites-enabled/static.openfoodfacts.net.conf
@@ -14,6 +14,7 @@ server {
     }
 
     listen 443 ssl; # managed by Certbot
+    http2 on;
     ssl_certificate /etc/letsencrypt/live/openfoodfacts.net/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/openfoodfacts.net/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot


### PR DESCRIPTION
## What

Enable HTTP/2 on the TLS virtual host shared by `static.openfoodfacts.net` and `images.openfoodfacts.net`.

Both hosts currently advertise only `http/1.1` through ALPN, while the equivalent `.org` hosts negotiate HTTP/2. The OVH reverse proxy is already running an nginx version that supports the `http2 on;` directive, and the same syntax is used by other virtual hosts on that proxy.

Only the client-facing reverse proxy needs HTTP/2; the upstream connection can remain HTTP/1.x.

## Verification

- `git diff --check`
- Confirmed the directive matches other nginx virtual hosts in this repository

Related to #453.