### PR TITLE
perf(nginx): reuse staging upstream connections

### DIFF
--- a/confs/ovh1-reverse-proxy/nginx/sites-enabled/beta.openfoodfacts.net.conf
+++ b/confs/ovh1-reverse-proxy/nginx/sites-enabled/beta.openfoodfacts.net.conf
@@ -1,3 +1,8 @@
+upstream explorer_staging {
+    server 10.1.0.200:3000;
+    keepalive 16;
+}
+
 server {
     listen 443 ssl; # managed by Certbot
     ssl_certificate /etc/letsencrypt/live/beta.openfoodfacts.net/fullchain.pem; # managed by Certbot
@@ -37,7 +42,9 @@ server {
 	#client_header_buffer_size 32k;
 	#large_client_header_buffers 4 128k;
 	# explorer is deployed on staging dockers
-        proxy_pass          http://10.1.0.200:3000/;
+        proxy_pass          http://explorer_staging/;
+        proxy_http_version  1.1;
+        proxy_set_header    Connection "";
         proxy_set_header    Host $host;
 	proxy_set_header    X-Real-IP $remote_addr;
 	proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/confs/ovh1-reverse-proxy/nginx/sites-enabled/static.openfoodfacts.net.conf
+++ b/confs/ovh1-reverse-proxy/nginx/sites-enabled/static.openfoodfacts.net.conf
@@ -1,3 +1,8 @@
+upstream static_openfoodfacts_net {
+    server 10.1.0.200:80;
+    keepalive 16;
+}
+
 server {
     # Special configuration to disable the HTTP basic auth off / off for the static
     # subdomain which causes CORS issues
@@ -7,7 +12,9 @@ server {
     error_log   /var/log/nginx/openfoodfacts.errors.log;
 
     location / {
-        proxy_pass http://10.1.0.200:80/;
+        proxy_pass http://static_openfoodfacts_net/;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_buffering off;
         proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header Host $host;


### PR DESCRIPTION
## What

Reuse upstream connections from the OVH nginx proxy to services on the staging Docker host (`10.1.0.200`):

- `static.openfoodfacts.net` and `images.openfoodfacts.net` on port 80
- Explorer at `beta.openfoodfacts.net` on port 3000

This change introduces separate named upstreams with pools of 16 idle keepalive connections. Each proxied location explicitly uses HTTP/1.1 and clears the `Connection` header so nginx can reuse upstream connections.

The existing URI handling, `Host` forwarding, proxy buffering, and Explorer buffer settings are preserved. Client-facing HTTP/2 remains independent from this upstream connection reuse.

## Why

Pages can request many static files and Explorer build assets. Reusing private-network upstream connections avoids repeated TCP connection setup and teardown and reduces connection churn on the staging host.

## Verification

- `git diff --check`
- Compared with the existing named-upstream keepalive pattern in this repository

Related to #677.