### PR TITLE
fix(nginx): reload after config symlink changes

### DIFF
--- a/ansible/roles/reverse_proxy_nginx/tasks/main.yml
+++ b/ansible/roles/reverse_proxy_nginx/tasks/main.yml
@@ -75,3 +75,5 @@
   git_based_config_symlinks:
     src: "{{ reverse_proxy_nginx__nginx_git_config_path }}"
     dst: "/etc/nginx"
+  notify:
+    - Reverse_proxy_nginx__reload_nginx


### PR DESCRIPTION
## Summary

- notify the existing NGINX reload handler when managed configuration symlinks change
- ensure updated reverse-proxy configuration is activated without a separate manual reload

## Validation

- `git diff --check`