### PR TITLE
feat: enable HTTP/2 for Robotoff

### DIFF
--- a/confs/ovh1-reverse-proxy/nginx/sites-enabled/robotoff.conf
+++ b/confs/ovh1-reverse-proxy/nginx/sites-enabled/robotoff.conf
@@ -21,6 +21,7 @@ server {
 
     listen [::]:443 ssl; # managed by Certbot
     listen 443 ssl; # managed by Certbot
+    http2 on;
     ssl_certificate /etc/letsencrypt/live/feedme.openfoodfacts.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/feedme.openfoodfacts.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot

--- a/confs/ovh1-reverse-proxy/nginx/sites-enabled/robotoff.openfoodfacts.net.conf
+++ b/confs/ovh1-reverse-proxy/nginx/sites-enabled/robotoff.openfoodfacts.net.conf
@@ -23,6 +23,7 @@ server {
 
 
     listen 443 ssl; # managed by Certbot
+    http2 on;
     ssl_certificate /etc/letsencrypt/live/robotoff.openfoodfacts.net/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/robotoff.openfoodfacts.net/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot


### PR DESCRIPTION
Enable HTTP/2 on the Robotoff HTTPS virtual hosts for robotoff.openfoodfacts.org and robotoff.openfoodfacts.net.